### PR TITLE
Renamed child task line in CSV to step

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -66,7 +66,7 @@ var exportCmd = &cobra.Command{
 				for _, t := range taskLists[i].Tasks {
 					outputBuilder.WriteString("\ntask," + t.Id + "," + t.Title + "," + t.Status + ",\"" + t.Body.Content + "\"," + t.DueDateTime.Time().String())
 					for _, c := range t.ChecklistItems {
-						outputBuilder.WriteString("\nchild task," + c.Id + "," + c.DisplayName + "," + strconv.FormatBool(c.IsChecked) + ",,")
+						outputBuilder.WriteString("\nstep," + c.Id + "," + c.DisplayName + "," + strconv.FormatBool(c.IsChecked) + ",,")
 					}
 				}
 			}


### PR DESCRIPTION
In the CSV output, steps would be listed with a type of "child task" which is consistent with the API however, the Microsoft To Do calls these items "steps". 

Renamed it to be consistent with the UI however, keeping it the same in the API libraries as that is how it is stated in the APIs.